### PR TITLE
Set version of layer releases-ios to v0.26.14

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "layerhq/releases-ios"
+github "layerhq/releases-ios" "v0.26.14"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "layerhq/releases-ios" "v0.26.9"
+github "layerhq/releases-ios" "v0.26.14"


### PR DESCRIPTION
Fix Layer's mess up in Release 4.0.0 by hard setting our used version of Layer to 0.26.14